### PR TITLE
ADD warnings property for S06 reports

### DIFF
--- a/primestg/report/reports.py
+++ b/primestg/report/reports.py
@@ -165,7 +165,7 @@ class ParameterS06(Parameter):
         self.concentrator_name = concentrator_name
         self.request_id = request_id
         self.meter_name = meter_name
-        self.warnings_list = []
+        self._warnings = []
 
     @property
     def concentrator_name(self):
@@ -267,8 +267,8 @@ class ParameterS06(Parameter):
                 'time_scroll_display': get_integer_value(get('ScrollDispTime'))
             }
         except Exception as e:
-            self.warnings_list.append('ERROR: Cnc({}), Meter({}). Thrown '
-                                      'exception: {}'.format(
+            self._warnings.append('ERROR: Cnc({}), Meter({}). Thrown '
+                                  'exception: {}'.format(
                 self.concentrator_name, self.meter_name, e.message))
         return values
 
@@ -279,7 +279,7 @@ class ParameterS06(Parameter):
 
         :return: a list with the errors found while reading
         """
-        return self.warnings_list
+        return self._warnings
 
 
 class ParameterS12(Parameter):
@@ -613,7 +613,7 @@ class MeterS06(MeterWithMagnitude):
         super(MeterS06, self).__init__(objectified_meter, concentrator_name)
         self.report_version = report_version
         self.request_id = request_id
-        self.warnings_list = []
+        self._warnings = []
 
     @property
     def report_version(self):
@@ -679,7 +679,7 @@ class MeterS06(MeterWithMagnitude):
         values = []
         for parameter in self.parameters:
             values.append(parameter.values)
-            self.warnings_list.extend(parameter.warnings)
+            self._warnings.extend(parameter.warnings)
         return values
 
     @property
@@ -689,7 +689,7 @@ class MeterS06(MeterWithMagnitude):
 
         :return: a list with the errors found reading the meter
         """
-        return self.warnings_list
+        return self._warnings
 
 
 class MeterS09(MeterWithConcentratorName):

--- a/primestg/report/reports.py
+++ b/primestg/report/reports.py
@@ -269,7 +269,7 @@ class ParameterS06(Parameter):
         except Exception as e:
             self._warnings.append('ERROR: Cnc({}), Meter({}). Thrown '
                                   'exception: {}'.format(
-                self.concentrator_name, self.meter_name, e.message))
+                self.concentrator_name, self.meter_name, e))
         return values
 
     @property

--- a/spec/Report_S06_spec.py
+++ b/spec/Report_S06_spec.py
@@ -8,6 +8,7 @@ with description('Report S06 example'):
 
         self.data_filenames = [
             'spec/data/S06.xml',
+            'spec/data/S06_with_error.xml',
             # 'spec/data/S06_empty.xml'
         ]
 
@@ -19,22 +20,27 @@ with description('Report S06 example'):
     with it('generates the expected results for the whole report'):
 
         result_filenames = []
+        warnings = []
         for data_filename in self.data_filenames:
             result_filenames.append('{}_result.txt'.format(data_filename))
 
         for key, result_filename in enumerate(result_filenames):
+            result = []
             with open(result_filename) as result_file:
                 result_string = result_file.read()
                 expected_result = literal_eval(result_string)
+            for cnc in self.report[key].concentrators:
+                if cnc.meters:
+                    for meter in cnc.meters:
+                        for value in meter.values:
+                            result.append(value)
+                        warnings.append(meter.warnings)
 
-        result = self.report[key].values
-        expect(result).to(equal(expected_result))
-        # result_filename = '{}_result.txt'.format(self.data_filename)
-        #
-        # with open(result_filename) as result_file:
-        #     result_string = result_file.read()
-        #     self.expected_result = literal_eval(result_string)
-        #
-        # result = self.report.values
-        #
-        # expect(result).to(equal(self.expected_result))
+            print('Result: {} \n Expected result: {} \n Warnings: {}'.format(
+                result, expected_result, warnings))
+
+            expect(result).to(equal(expected_result))
+        expected_warnings = [[], ["ERROR: Cnc(CIR4621704174), "
+                                  "Meter(ZIV42553686). Thrown exception: "
+                                  "object of type 'NoneType' has no len()"], []]
+        expect(warnings).to(equal(expected_warnings))

--- a/spec/data/S06_with_error.xml
+++ b/spec/data/S06_with_error.xml
@@ -1,0 +1,10 @@
+<Report IdRpt="S06" IdPet="361362" Version="3.1.c">
+	<Cnc Id="CIR4621704174">
+		<Cnt Id="ZIV42553686">
+			<S06 NS="" Fab="" Mod="" Af="" Te="" Vf="" VPrime="" Pro="" Idm="" Mac="00:80:E1:15:25:55" Tp="" Ts="" Ip="" Is="" Usag="" Uswell="" Per="" Dctcp="" Vr="" Ut="" UsubT="" UsobT="" UcorteT="" AutMothBill="" ScrollDispMode="" ScrollDispTime="" />
+		</Cnt>
+		<Cnt Id="ZIV36301516">
+			<S06 Fh="20180101204134000W" NS="0019722616" Fab=" C" Mod="YK" Af="12" Te="contador  " Vf="V0408" VPrime="1.2.6d_R" Pro="DLMS0105" Idm="Deuice ID 6" Mac="00:80:E1:15:42:96" Tp="" Ts="" Ip="" Is="" Usag="180" Uswell="180" Per="3600" Dctcp="95.00" Vr="230" Ut="180" UsubT="7.00" UsobT="7.00" UcorteT="50.00" AutMothBill="Y" ScrollDispMode="A" ScrollDispTime="3" />
+		</Cnt>
+	</Cnc>
+</Report>

--- a/spec/data/S06_with_error.xml_result.txt
+++ b/spec/data/S06_with_error.xml_result.txt
@@ -1,0 +1,38 @@
+[
+    {
+    },
+    {
+        'protocol': 'DLMS0105',
+        'concentrator': 'CIR4621704174',
+        'timestamp': '2018-01-01 20:41:34',
+        'secondary_voltage': 0,
+        'prime_firmware_version': '1.2.6d_R',
+        'meter': 'ZIV36301516',
+        'mac': '00:80:E1:15:42:96',
+        'time_threshold_voltage_swells': 180,
+        'time_threshold_voltage_sags': 180,
+        'secondary_current': 0,
+        'firmware_version': 'V0408',
+        'primary_current': 0,
+        'voltage_cut-off_threshold': '50.00',
+        'manufacturer': ' C',
+        'equipment_type': 'contador  ',
+        'voltage_swell_threshold': '7.00',
+        'manufacturing_year': 12,
+        'load_profile_period': 3600,
+        'primary_voltage': 0,
+        'id_multicast': 'Deuice ID 6',
+        'scroll_display_mode': 'A',
+        'season': 'W',
+        'demand_close_contracted_power': '95.00',
+        'version': '3.1.c',
+        'reference_voltage': 230,
+        'request_id': '361362',
+        'model_type': 'YK',
+        'serial_number': '0019722616',
+        'automatic_monthly_billing': True,
+        'time_scroll_display': 3,
+        'voltage_sag_threshold': '7.00',
+        'long_power_failure_threshold': 180
+    }
+]


### PR DESCRIPTION
Will add the "warnings" property to the PrimeSTG objects to make the library able to return a list of errors found while reading the reports.