### PR TITLE
Warnings property for s04 && Raise error when wrong date 

### DIFF
--- a/primestg/report/base.py
+++ b/primestg/report/base.py
@@ -46,8 +46,8 @@ class ValueWithTime(object):
             time = datetime.strptime(date_value[:-1],
                                      '%Y%m%d%H%M%S')
         except ValueError as e:
-            now = datetime.now().strftime("%Y%m%d%H%M%S")
-            time = datetime.strptime(now, '%Y%m%d%H%M%S')
+            raise ValueError("Date out of range: {} ({}) {}".format(
+                date_value, name, e))
         return time.strftime('%Y-%m-%d %H:%M:%S')
 
 

--- a/primestg/report/base.py
+++ b/primestg/report/base.py
@@ -65,6 +65,7 @@ class Measure(ValueWithTime):
         :return: a Measure object
         """
         self.objectified = objectified_measure
+        self._warnings = []
 
     @property
     def objectified(self):
@@ -85,6 +86,15 @@ class Measure(ValueWithTime):
         :return:
         """
         self._objectified = value
+
+    @property
+    def warnings(self):
+        """
+        Warnings of these measures.
+
+        :return: a list with the errors found while reading
+        """
+        return self._warnings
 
 
 class MeasureActiveReactive(Measure):
@@ -235,6 +245,7 @@ class Meter(object):
         :return: a Meter object
         """
         self.objectified = objectified_meter
+        self._warnings = []
 
     @property
     def objectified(self):
@@ -317,7 +328,17 @@ class Meter(object):
         values = []
         for measure in self.measures:
             values.append(measure.value())
+            self._warnings.extend(measure.warnings)
         return values
+
+    @property
+    def warnings(self):
+        """
+        Warnings of this meter.
+
+        :return: a list with the errors found while reading
+        """
+        return self._warnings
 
 
 class MeterWithConcentratorName(Meter):
@@ -378,6 +399,8 @@ class MeterWithConcentratorName(Meter):
                 v['name'] = self.name
                 v['cnc_name'] = self.concentrator_name
                 values.append(v)
+            for warning in measure.warnings:
+                self._warnings.append("WARNING: {}".format(warning))
         return values
 
 

--- a/primestg/report/reports.py
+++ b/primestg/report/reports.py
@@ -53,24 +53,27 @@ class MeasureS04(MeasureActiveReactive):
         :return: a dict with a set of measures of report S04
         """
         values = []
-        common_values = {
-            'type': 'month',
-            'date_begin': self._get_timestamp('Fhi'),
-            'date_end': self._get_timestamp('Fhf'),
-            'contract': int(self.objectified.get('Ctr')),
-            'period': int(self.objectified.get('Pt')),
-            'max': int(self.objectified.get('Mx')),
-            'date_max': self._get_timestamp('Fx')
-        }
-        for s04_values in self.objectified.Value:
-            v = common_values.copy()
-            if s04_values.get('AIa'):
-                measure_type = 'a'
-            else:
-                measure_type = 'i'
-            v.update(self.active_reactive(s04_values, measure_type))
-            v['value'] = measure_type
-            values.append(v)
+        try:
+            common_values = {
+                'type': 'month',
+                'date_begin': self._get_timestamp('Fhi'),
+                'date_end': self._get_timestamp('Fhf'),
+                'contract': int(self.objectified.get('Ctr')),
+                'period': int(self.objectified.get('Pt')),
+                'max': int(self.objectified.get('Mx')),
+                'date_max': self._get_timestamp('Fx')
+            }
+            for s04_values in self.objectified.Value:
+                v = common_values.copy()
+                if s04_values.get('AIa'):
+                    measure_type = 'a'
+                else:
+                    measure_type = 'i'
+                v.update(self.active_reactive(s04_values, measure_type))
+                v['value'] = measure_type
+                values.append(v)
+        except Exception as e:
+            self._warnings.append('ERROR: Thrown exception: {}'.format(e))
         return values
 
 


### PR DESCRIPTION
- Warnings property for s04:
Adds the property WARNINGS to the MeterS04 object.
Adds the firsts steps to add the WARNINGS property to others reports.

- Raise error when wrong date:
Adding the property the the S04 report i realized that not rising an exception when a wrong date was found on a file was a potential error. It was right to do so for the S06 report because its dates are just for information, but S04 dates have a relevant meaning when creating the billings.