### PR TITLE
ADD supported_list public getter

### DIFF
--- a/primestg/report/reports.py
+++ b/primestg/report/reports.py
@@ -9,6 +9,10 @@ SUPPORTED_REPORTS = ['S02', 'S04', 'S05', 'S06', 'S09', 'S12', 'S13', 'S15',
                      'S17']
 
 
+def is_supported(report_code):
+    return report_code in SUPPORTED_REPORTS
+
+
 def get_integer_value(param):
     try:
         result = int(param)

--- a/primestg/report/reports.py
+++ b/primestg/report/reports.py
@@ -1234,7 +1234,7 @@ class Report(object):
 
     @property
     def supported(self):
-        return self.report_type in SUPPORTED_REPORTS
+        return is_supported(self.report_type)
 
     @property
     def concentrators(self):


### PR DESCRIPTION
New getter function to receive the list of all the PRIME codes of the supported reports.

The property that existed to do that required an already built Report object to call it. This one doesn't because is an static method