### PR TITLE
New B04 contract modification order

### DIFF
--- a/primestg/cli.py
+++ b/primestg/cli.py
@@ -55,7 +55,7 @@ def get_sync_report(**kwargs):
         res = func(kwargs['meter'])
     except:
         res = func(kwargs['meter'], '2019-01-01 00:00:00', '2019-01-01 00:00:00')
-    print res
+    print(res)
 
 
 # Gets a raw report
@@ -75,7 +75,7 @@ def get_sync_sxx(**kwargs):
    id_pet = get_id_pet()
    s = Service(id_pet, kwargs['cnc_url'], sync=sync, source='DCF')
    res = s.send(kwargs['sxx'],kwargs['meter'])
-   print res
+   print(res)
 
 
 # Sends an order
@@ -126,7 +126,7 @@ def sends_order(**kwargs):
 
    func = getattr(s, ORDERS[order_name]['func'])
    res = func(generic_values, vals)
-   print res
+   print(res)
 
 
 # Sends a CNC Txx order (B11)
@@ -149,7 +149,7 @@ def cnc_control(**kwargs):
        'date_to': format_timestamp(datetime.now())
    }
    res = s.get_order_request(generic_values, vals)
-   print res
+   print(res)
 
 
 # Gets available contract templates

--- a/primestg/cli.py
+++ b/primestg/cli.py
@@ -2,6 +2,9 @@
 import sys                                                                      
 import click
 from datetime import datetime, timedelta
+from pytz import timezone
+
+TZ = timezone('Europe/Madrid')
 
 from primestg.service import Service, format_timestamp
 
@@ -12,11 +15,14 @@ REPORTS = [
     'get_concentrator_parameters',
 ]
 
-ORDERS = [
-    'cutoff',
-    'reconnect',
-    'connect'
-]
+ORDERS = {
+    # CUTOFF
+    'cutoff': {'order': 'B03', 'func': 'get_cutoff_reconnection'},
+    'reconnect': {'order': 'B03', 'func': 'get_cutoff_reconnection'},
+    'connect': {'order': 'B03', 'func': 'get_cutoff_reconnection'},
+    # CONTRACT
+    'contract': {'order': 'B04', 'func': 'get_contract'},
+}
 
 def get_id_pet():
     now = datetime.now()
@@ -75,33 +81,47 @@ def get_sync_sxx(**kwargs):
                 default="http://cct.gisce.lan:8080"
 )   
 @click.option("--meter", "-m", default="ZIV0040318130")
+@click.option("--contract", "-c", default="1")
+@click.option("--tariff", "-t", default="2.0_ST")
+@click.option("--activation_date", "-d", default="2021-04-01 00:00:00")
 def sends_order(**kwargs):
    id_pet = get_id_pet()
    s = Service(id_pet, kwargs['cnc_url'], sync=True)
+   order_name = kwargs['order']
+   order_code = ORDERS[order_name]['order']
    generic_values = {
        'id_pet': id_pet,
-       'id_req': 'B03',
+       'id_req': order_code,
        'cnc': 'ZIV0004394488',
        'cnt': kwargs['meter'],
    }
-   if kwargs['order'] == 'cutoff':
+   if order_name == 'cutoff':
        vals = {
            'order_param': '0',
        }
-   elif kwargs['order'] == 'reconnect':
+   elif order_name == 'reconnect':
        vals = {
            'order_param': '1'
        }
-   elif kwargs['order'] == 'connect':
+   elif order_name == 'connect':
        vals = {
            'order_param': '2'
+       }
+   elif order_name == 'contract':
+       vals = {
+           'contract': kwargs['contract'],
+           'name': kwargs['tariff'],
+           'activation_date': TZ.localize(
+               datetime.strptime(kwargs['activation_date'], '%Y-%m-%d %H:%M:%S')
+           )
        }
    vals.update({
        'date_to': format_timestamp(datetime.now()+timedelta(hours=1)),
        'date_from': format_timestamp(datetime.now()),
    })
 
-   res = s.get_cutoff_reconnection(generic_values, vals)
+   func = getattr(s, ORDERS[order_name]['func'])
+   res = func(generic_values, vals)
    print res
 
 # Sends a CNC Txx order (B11)

--- a/primestg/cli.py
+++ b/primestg/cli.py
@@ -7,6 +7,8 @@ from pytz import timezone
 TZ = timezone('Europe/Madrid')
 
 from primestg.service import Service, format_timestamp
+from primestg.contract_templates import CONTRACT_TEMPLATES
+
 
 REPORTS = [
     'get_instant_data',
@@ -33,6 +35,7 @@ def get_id_pet():
 @click.group(name="primestg")
 def primestg(**kwargs):
     pass
+
 
 # Gets a specific report by name
 @primestg.command(name='report')                                                       
@@ -74,6 +77,7 @@ def get_sync_sxx(**kwargs):
    res = s.send(kwargs['sxx'],kwargs['meter'])
    print res
 
+
 # Sends an order
 @primestg.command(name='order')
 @click.argument('order', type=click.Choice(ORDERS), required=True)
@@ -82,7 +86,7 @@ def get_sync_sxx(**kwargs):
 )   
 @click.option("--meter", "-m", default="ZIV0040318130")
 @click.option("--contract", "-c", default="1")
-@click.option("--tariff", "-t", default="2.0_ST")
+@click.option("--tariff", "-t", default="2.0_ST", help="One of available templates (see primestg templates)")
 @click.option("--activation_date", "-d", default="2021-04-01 00:00:00")
 def sends_order(**kwargs):
    id_pet = get_id_pet()
@@ -124,6 +128,7 @@ def sends_order(**kwargs):
    res = func(generic_values, vals)
    print res
 
+
 # Sends a CNC Txx order (B11)
 @primestg.command(name='cnc_control')
 @click.argument('order',required=True)
@@ -145,6 +150,16 @@ def cnc_control(**kwargs):
    }
    res = s.get_order_request(generic_values, vals)
    print res
+
+
+# Gets available contract templates
+@primestg.command(name='templates')
+def get_contract_templates(**kwargs):
+    print('# Available contract templates for B04 order:\n')
+    for name in sorted(CONTRACT_TEMPLATES.keys()):
+        data = CONTRACT_TEMPLATES[name]
+        print(' * {}: {}'.format(name, data['description']))
+
 
 if __name__ == 'main':
     primestg()

--- a/primestg/contract_templates.py
+++ b/primestg/contract_templates.py
@@ -57,7 +57,7 @@ CONTRACT_TEMPLATES = {
         }
     },
     'DHS_IT': {
-        'description': '2.xDHS 2 period contracts (Triple Tariff)',
+        'description': '2.xDHS 3 period contracts (Triple Tariff)',
         'origin': 'library',
         'type': '01',
         'seasons': [

--- a/primestg/contract_templates.py
+++ b/primestg/contract_templates.py
@@ -1,0 +1,250 @@
+# -*- coding: utf-8 -*-
+
+CONTRACT_TEMPLATES = {
+    '2.0_ST': {
+        'description': '2.x 1 period contracts (Simple Tariff)',
+        'origin': 'library',
+        'type': '01',
+        'seasons': [
+            {
+                'name': '01',
+                'start': 'FFFFFEFFFFFFFF0000800080',
+                'week': '01'
+            }
+        ],
+        'weeks': [
+            {
+                'name': '01', 'week': '01010101010101'
+            }
+        ],
+        'days': {
+          '01': [{'hour': 1, 'period': 1}]
+        }
+    },
+    'DHA_IT': {
+        'description': '2.xDHA 2 period contracts (Double Tariff)',
+        'origin': 'library',
+        'type': '01',
+        'seasons': [
+          {
+            'name': '01',
+            'start': 'FFFFFEFFFFFFFF0000800080',
+            'week': '01'
+          },
+          {
+            'name': '02',
+            'start': 'FFFFFDFFFFFFFF0000800000',
+            'week': '02'
+          }
+        ],
+        'weeks': [
+          {
+            'name': '01', 'week': '01010101010101'
+          },
+          {
+            'name': '02', 'week': '02020202020202'
+          }
+        ],
+        'days': {
+            '01': [
+                {'hour': 13, 'period': 1},
+                {'hour': 23, 'period': 2}
+            ],
+            '02': [
+                {'hour': 12, 'period': 1},
+                {'hour': 22, 'period': 2}
+            ]
+        }
+    },
+    'DHS_IT': {
+        'description': '2.xDHS 2 period contracts (Triple Tariff)',
+        'origin': 'library',
+        'type': '01',
+        'seasons': [
+            {
+              'name': '01',
+              'start': 'FFFFFEFFFFFFFF0000800080',
+              'week': '01'
+            },
+            {
+              'name': '02',
+              'start': 'FFFFFDFFFFFFFF0000800000',
+              'week': '02'
+            }
+        ],
+        'weeks': [
+            {
+                'name': '01', 'week': '01010101010101'
+            },
+            {
+                'name': '02', 'week': '02020202020202'
+            }
+        ],
+        'days': {
+            '01': [
+                {'hour': 1, 'period': 3},
+                {'hour': 7, 'period': 2},
+                {'hour': 13, 'period': 23}
+            ],
+            '02': [
+                {'hour': 1, 'period': 3},
+                {'hour': 7, 'period': 2},
+                {'hour': 13, 'period': 23}
+            ]
+        },
+    },
+    # 3/2020
+    '2.0TDA': {
+        'description': '2.0TDA 3 periods and special days',
+        'origin': 'library',
+        'type': '01',
+        'seasons': [
+            {
+                'name': '01',
+                'start': 'FFFF0101FF00000000800000',
+                'week': '01'
+            },
+        ],
+        'weeks': [
+            {'name': '01', 'week': '01010101010202'}
+        ],
+        'days': {
+            '01': [
+                {'hour': 0, 'period': 3},
+                {'hour': 8, 'period': 2},
+                {'hour': 9, 'period': 1},
+                {'hour': 14, 'period': 2},
+                {'hour': 18, 'period': 1},
+                {'hour': 22, 'period': 2}
+            ],
+            '02': [
+                {'hour': 0, 'period': 3},
+            ],
+        },
+        'special_days': [
+            {'datetime': 'FFFF0101000000000W', 'datetime_card': True, 'day_id': '03'},
+            {'datetime': 'FFFF0106000000000W', 'datetime_card': True, 'day_id': '03'},
+            {'datetime': 'FFFF0501000000000S', 'datetime_card': True, 'day_id': '03'},
+            {'datetime': 'FFFF0815000000000S', 'datetime_card': True, 'day_id': '03'},
+            {'datetime': 'FFFF1012000000000S', 'datetime_card': True, 'day_id': '03'},
+            {'datetime': 'FFFF1101000000000W', 'datetime_card': True, 'day_id': '03'},
+            {'datetime': 'FFFF1206000000000W', 'datetime_card': True, 'day_id': '03'},
+            {'datetime': 'FFFF1208000000000W', 'datetime_card': True, 'day_id': '03'},
+            {'datetime': 'FFFF1225000000000W', 'datetime_card': True, 'day_id': '03'},
+        ],
+    },
+    '3.0TDA': {
+        'description': '3.0TDA with seasons and special days',
+        'origin': 'library',
+        'type': '01',
+        'seasons': [
+            {
+                'name': '01',
+                'start': 'FFFF0101FF00000000800000',
+                'week': '01'
+            },
+            {
+                'name': '02',
+                'start': 'FFFF0301FF00000000800000',
+                'week': '02'
+            },
+            {
+                'name': '03',
+                'start': 'FFFF0401FF00000000800000',
+                'week': '03'
+            },
+            {
+                'name': '04',
+                'start': 'FFFF0601FF00000000800000',
+                'week': '04'
+            },
+            {
+                'name': '05',
+                'start': 'FFFF0701FF00000000800000',
+                'week': '01'
+            },
+            {
+                'name': '06',
+                'start': 'FFFF0801FF00000000800000',
+                'week': '04'
+            },
+            {
+                'name': '07',
+                'start': 'FFFF0A01FF00000000800000',
+                'week': '03'
+            },
+            {
+                'name': '08',
+                'start': 'FFFF0B01FF00000000800000',
+                'week': '02'
+            },
+            {
+                'name': '09',
+                'start': 'FFFF0C01FF00000000800000',
+                'week': '01'
+            },
+        ],
+        'weeks': [
+            {
+                'name': '01', 'week': '01010101010505'
+            },
+            {
+                'name': '02', 'week': '02020202020505'
+            },
+            {
+                'name': '03', 'week': '04040404040505'
+            },
+            {
+                'name': '04', 'week': '03030303030505'
+            }
+        ],
+        'days': {
+            '01': [
+                {'hour': 0, 'period': 6},
+                {'hour': 8, 'period': 2},
+                {'hour': 9, 'period': 1},
+                {'hour': 14, 'period': 2},
+                {'hour': 18, 'period': 1},
+                {'hour': 22, 'period': 2}
+            ],
+            '02': [
+                {'hour': 0, 'period': 6},
+                {'hour': 8, 'period': 3},
+                {'hour': 9, 'period': 2},
+                {'hour': 14, 'period': 3},
+                {'hour': 18, 'period': 2},
+                {'hour': 22, 'period': 3}
+            ],
+            '03': [
+                {'hour': 0, 'period': 6},
+                {'hour': 8, 'period': 4},
+                {'hour': 9, 'period': 3},
+                {'hour': 14, 'period': 4},
+                {'hour': 18, 'period': 3},
+                {'hour': 22, 'period': 4}
+            ],
+            '04': [
+                {'hour': 0, 'period': 6},
+                {'hour': 8, 'period': 5},
+                {'hour': 9, 'period': 4},
+                {'hour': 14, 'period': 5},
+                {'hour': 18, 'period': 4},
+                {'hour': 22, 'period': 5}
+            ],
+            '05': [
+                {'hour': 0, 'period': 6},
+            ]
+        },
+        'special_days': [
+            {'datetime': 'FFFF0101000000000W', 'datetime_card': True, 'day_id': '05'},
+            {'datetime': 'FFFF0106000000000W', 'datetime_card': True, 'day_id': '05'},
+            {'datetime': 'FFFF0501000000000S', 'datetime_card': True, 'day_id': '05'},
+            {'datetime': 'FFFF0815000000000S', 'datetime_card': True, 'day_id': '05'},
+            {'datetime': 'FFFF1012000000000S', 'datetime_card': True, 'day_id': '05'},
+            {'datetime': 'FFFF1101000000000W', 'datetime_card': True, 'day_id': '05'},
+            {'datetime': 'FFFF1206000000000W', 'datetime_card': True, 'day_id': '05'},
+            {'datetime': 'FFFF1208000000000W', 'datetime_card': True, 'day_id': '05'},
+            {'datetime': 'FFFF1225000000000W', 'datetime_card': True, 'day_id': '05'},
+        ]
+    }
+}

--- a/primestg/order/orders.py
+++ b/primestg/order/orders.py
@@ -1,8 +1,6 @@
 from libcomxml.core import XmlModel, XmlField
-from collections import OrderedDict
 from primestg.order.base import (OrderHeader, CntOrderHeader)
 from primestg.utils import ContractTemplates, datetimetoprime
-from datetime import datetime
 from pytz import timezone
 
 
@@ -218,7 +216,7 @@ class B04Payload(XmlModel):
     Supported parameters:
         contract: One of available contracts (1,2,3)
         template: Name of one of available templates
-        activation_date: Activation date if latent. Admits wildcards: YYYYMMDDHH (FFFF0101FF)
+        activation_date: Activation date if latent (localized or not python datetime)
 
     :return: B04 parameters
 

--- a/primestg/order/orders.py
+++ b/primestg/order/orders.py
@@ -1,7 +1,14 @@
 from libcomxml.core import XmlModel, XmlField
+from collections import OrderedDict
 from primestg.order.base import (OrderHeader, CntOrderHeader)
+from primestg.utils import ContractTemplates, datetimetoprime
+from datetime import datetime
+from pytz import timezone
 
-SUPPORTED_ORDERS = ['B03', 'B09', 'B11']
+
+TZ = timezone('Europe/Madrid')
+
+SUPPORTED_ORDERS = ['B03', 'B04', 'B09', 'B11']
 
 
 def is_supported(order_code):
@@ -47,6 +54,233 @@ class B03Payload(XmlModel):
                 'Ffin': payload.get('date_to'),
             })
         super(B03Payload, self).__init__('b03Payload', 'payload', drop_empty=drop_empty)
+
+
+# B04 Node classes
+class Contract(XmlModel):
+    """
+    The class to instance B04 Contract
+    Parameters:
+        contract: Contract number (1,2,3)
+        calendar_type: Calendar type:
+            '01': season
+            '0A': summer/winter
+        'name': 6 ascii chars calendar name i.e '2.0TDA'
+        'activation_date':  Datetime of activation localized or not. It gets always CE(S)T timezone
+    """
+    _sort_order = ('contract', 'seasons_list', 'weeks_list', 'days_list', 'special_days_list')
+
+    def __init__(self, payload, drop_empty=False):
+        self.contract = XmlField(
+            'Contract', attributes={
+                'c': str(payload.get('contract')),
+                'CalendarType': payload.get('calendar_type', '01'),
+                'CalendarName': self.name2octet(payload.get('name')),
+                'ActDate': payload.get('activation_date'),
+            }
+        )
+        self.seasons_list = []
+        self.weeks_list = []
+        self.days_list = []
+        self.special_days_list = []
+        super(Contract, self).__init__(
+            'Contract', 'contract', drop_empty=drop_empty
+        )
+
+    @staticmethod
+    def name2octet(txt):
+        octet_str = ''
+        for caracter in '{: >6}'.format(txt):
+            octet_str += '{0:2x}'.format(ord(caracter)).upper()
+        return octet_str
+
+    @staticmethod
+    def octet2name(txt):
+        name = ''
+        for index in range(0, len(txt), 2):
+            name += chr(int(txt[index] + txt[index + 1], 16))
+        return name
+
+
+class Season(XmlModel):
+    """
+    The class to instance B04 Seasons
+    Parameters:
+        name: Season Name i.e 01
+        start_date: Datetime string with Wildcards i.e: FFFF0101FF00000000800000
+        week: Week Name i.e: 01
+    """
+    def __init__(self, payload, drop_empty=False):
+        self.season = XmlField(
+            'Season', attributes={
+                'Name': payload.get('name'),
+                'Start': payload.get('start'),
+                'Week': payload.get('week')
+            }
+        )
+        super(Season, self).__init__('Season', 'season', drop_empty=drop_empty)
+
+class Week(XmlModel):
+    """
+    The class to instance B04 Week
+    Parameters:
+        name: Week Name i.e 01
+        week: String with 7 day names (one per day) i.e. "01010101010202"
+    """
+    def __init__(self, payload, drop_empty=False):
+        self.week = XmlField(
+            'Week', attributes={
+                'Name': payload.get('name'),
+                'Week': payload.get('week')
+            }
+        )
+        super(Week, self).__init__('Week', 'week', drop_empty=drop_empty)
+
+
+class SpecialDays(XmlModel):
+    """
+    The class to instance B04 Special Days
+    Parameters:
+        datetime: PRIME Datetime with wildcards, i.e: FFFF0101000000000W
+        datetime_card:
+            True: Year as Wildcard (Y)
+            False: Year as is      (N)
+        day_id: Day Id as defined in Day spec (i.e: "01")
+    """
+    def __init__(self, payload, drop_empty=False):
+        self.specialdays = XmlField(
+            'SpecialDays', attributes={
+                'DT': payload.get('datetime'),
+                'DTCard': payload.get('datetime_card') and 'Y' or 'N',
+                'DayID': payload.get('day_id')
+            }
+        )
+        super(SpecialDays, self).__init__('SpecialDays', 'specialdays', drop_empty=drop_empty)
+
+
+class ChangeHour(XmlModel):
+    """
+    The class to instance B04 Period Change Hour
+    Parameters:
+        hour: integer (0 to 23)
+        period: integer(1 to 6)
+    """
+
+    def __init__(self, payload, drop_empty=False):
+        self.change_hour = XmlField(
+            'Change', attributes={
+                'Hour': "{0:02x}000000".format(payload.get('hour')).upper(),
+                'TariffRate': "{0:04d}".format(payload.get('period'))
+            }
+        )
+        super(ChangeHour, self).__init__('ChangeHour', 'change_hour')
+
+
+class Day(XmlModel):
+    """
+    The class to instance B04 Day
+    Parameters:
+        id: day id i.e 01
+        days: ChangeHour class list
+    """
+
+    _sort_order = ('day', 'change_hour_list')
+
+    def __init__(self, payload, drop_empty=False):
+        self.day = XmlField(
+            'Day', attributes={'id': payload.get('id')}
+        )
+        self.change_hour_list = []
+        super(Day, self).__init__('Day', 'day', drop_empty=drop_empty)
+
+
+class B04:
+    """
+    The class used to instance B04 order.
+
+    :return: B04 order with parameters
+    """
+    def __init__(self, generic_values, payload):
+        self.generic_values = generic_values
+        self.order = CntOrderHeader(
+            generic_values.get('id_pet'),
+            generic_values.get('id_req'),
+            generic_values.get('cnc'),
+            generic_values.get('cnt')
+        )
+        self.order.cnc.cnt.feed({'payload': B04Payload(payload)})
+        # Load generic order with values
+
+
+class B04Payload(XmlModel):
+    """
+    The class used to instance B04 parameters.
+    Supported parameters:
+        contract: One of available contracts (1,2,3)
+        template: Name of one of available templates
+        activation_date: Activation date if latent. Admits wildcards: YYYYMMDDHH (FFFF0101FF)
+
+    :return: B04 parameters
+
+    """
+
+    _sort_order = ('payload', 'contract',)
+
+    def __init__(self, payload,  drop_empty=False):
+        contract = payload.get('contract')
+        template_name = payload.get('name')
+        act_date_param = payload.get('activation_date')
+
+        activation_date = datetimetoprime(act_date_param)
+
+        # Get template
+        ct = ContractTemplates()
+        tmpl = ct.get_template(template_name)
+
+        # Creates lists
+        seasons = []
+        for season in tmpl['seasons']:
+            seasons.append(
+                Season(season)
+            )
+
+        weeks = []
+        for week in tmpl['weeks']:
+            weeks.append(
+                Week(week)
+            )
+
+        days = []
+        for day_id in sorted(tmpl['days']):
+            hours = tmpl['days'][day_id]
+            chs = []
+            for ch in hours:
+                chs.append(ChangeHour(ch))
+            day = Day({'id': day_id})
+            day.feed({'change_hour_list': chs})
+            days.append(day)
+
+        special_days = []
+        for sp_day in tmpl.get('special_days', []):
+            special_days.append(
+                SpecialDays(sp_day)
+            )
+
+        self.payload = XmlField('B04')
+        self.contract = Contract(
+                {'name': template_name, 'contract': contract, 'activation_date': activation_date}
+            )
+
+        self.contract.feed(
+            {
+                'seasons_list': seasons,
+                'weeks_list': weeks,
+                'days_list': days,
+                'special_days_list': special_days
+            }
+        )
+
+        super(B04Payload, self).__init__('b04Payload', 'payload', drop_empty=drop_empty)
 
 
 class B09:
@@ -169,6 +403,10 @@ class Order(object):
         order_type_class = {
             'B03': {
                 'class': B03,
+                'args': [generic_values, payload]
+            },
+            'B04': {
+                'class': B04,
                 'args': [generic_values, payload]
             },
             'B09': {

--- a/primestg/report/base.py
+++ b/primestg/report/base.py
@@ -29,6 +29,11 @@ S23_BAD_TIMESTAMP = [
 BAD_TIMESTAMP = SAGE_BAD_TIMESTAMP + S23_BAD_TIMESTAMP
 
 
+DAYSAVING_START_TS = 'FFFFFDFFFFFFFF0000800000'   # Winter to summer
+DAYSAVING_END_TS = 'FFFFFEFFFFFFFF0000800080'     # Summer to winter
+NOW_ACTIVATION_DATE = 'FFFFFFFFFFFFFFFFFF800009'  # Instantly activate latent contract
+
+
 class ValueWithTime(object):
     """
     Base class for values with time.

--- a/primestg/service.py
+++ b/primestg/service.py
@@ -74,6 +74,15 @@ class Service(object):
         order = order.create(generic_values, payload)
         return self.send_order('B03', order)
 
+    def get_contract(self, generic_values, payload):
+        """
+        Sends B03 order to meter
+        :return: Success or fail
+        """
+        order = Order('B04')
+        order = order.create(generic_values, payload)
+        return self.send_order('B04', order)
+
     def get_meter_modification(self, generic_values, payload):
         """
         Sends B09 order to meter

--- a/primestg/utils.py
+++ b/primestg/utils.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 from lxml.doctestcompare import LXMLOutputChecker
 from doctest import Example
-from contract_templates import CONTRACT_TEMPLATES
-from datetime import datetime
+from .contract_templates import CONTRACT_TEMPLATES
 from pytz import timezone
 from copy import copy
 

--- a/primestg/utils.py
+++ b/primestg/utils.py
@@ -2,6 +2,12 @@
 # -*- coding: utf-8 -*-
 from lxml.doctestcompare import LXMLOutputChecker
 from doctest import Example
+from contract_templates import CONTRACT_TEMPLATES
+from datetime import datetime
+from pytz import timezone
+from copy import copy
+
+TZ = timezone('Europe/Madrid')
 
 
 def assertXMLEqual(got, want):
@@ -11,3 +17,39 @@ def assertXMLEqual(got, want):
     message = checker.output_difference(Example(u"", want), got, 0)
     raise AssertionError(message)
 
+
+def datetimetoprime(dt):
+    """
+    Converts a datetime (localized or not) to a prime datetime string.
+    """
+    dt_param = copy(dt)
+    if dt.tzinfo is None:
+        dt_param = TZ.normalize(TZ.localize(dt_param))
+    season = dt_param.dst() and 'S' or 'W'
+    dt_str = dt_param.strftime(
+        '%Y%m%d%H%M%S000{}'.format(season)
+    )
+    return dt_str
+
+
+class ContractTemplates:
+
+    def __init__(self):
+        self.templates = CONTRACT_TEMPLATES
+
+    def get_available_templates(self, origin=None):
+        template_list = []
+        for name, contract in self.templates.items():
+            if origin is not None:
+                if contract['origin'] != origin:
+                    continue
+            template_list.append(
+                (name, contract['description'], contract['origin'])
+            )
+        return template_list
+
+    def get_template(self, name):
+        try:
+            return self.templates[name]
+        except Exception as e:
+            raise KeyError('Template not available')

--- a/spec/Order_B04_spec.py
+++ b/spec/Order_B04_spec.py
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+from primestg.order.orders import Order, Contract
+from primestg.utils import ContractTemplates, CONTRACT_TEMPLATES, datetimetoprime
+from expects import expect, equal, contain, be_a, raise_error
+from primestg.utils import assertXMLEqual
+from datetime import datetime
+from pytz import timezone
+
+TZ = timezone('Europe/Madrid')
+
+
+with description('Order B04 Generation'):
+
+    with context('Support utilities'):
+
+        with context('datetimetoprime: datetime to PRIME format'):
+
+            with it('Generates a correct string from datetimes'):
+                dates = [
+                    (datetime(2020, 1, 1, 0), '20200101000000000W'),
+                    (datetime(2020, 8, 1, 2, 3, 4), '20200801020304000S')
+                ]
+
+                for dt in dates:
+                    expect(datetimetoprime(dt[0])).to(equal(dt[1]))
+                    # localize
+                    local_dt = TZ.normalize(TZ.localize(dt[0]))
+                    expect(datetimetoprime(local_dt)).to(equal(dt[1]))
+
+        with context('in Contract class'):
+
+            with it('Contract.name2code converts string to octet string'):
+                name = '6.1_TDA'
+                octet = Contract.name2octet(name)
+                new_name = Contract.octet2name(octet)
+                expect(new_name).to(equal(name))
+
+        with context('ContractTemplates class'):
+
+            with before.all:
+                self.ct = ContractTemplates()
+
+            with it('may be instantiated'):
+                expect(self.ct).to(be_a(ContractTemplates))
+
+            with it('returns templates list'):
+                templates = self.ct.get_available_templates()
+                expect(len(templates)).to(equal(len(CONTRACT_TEMPLATES)))
+                for tmpl in templates:
+                    name, description, origin = tmpl
+                    expect(CONTRACT_TEMPLATES.keys()).to(contain(name))
+                    contract_tmpl = CONTRACT_TEMPLATES[name]
+                    expect(contract_tmpl['description']).to(equal(description))
+                    expect(contract_tmpl['origin']).to(equal(origin))
+
+            with it('returns only selected library origin'):
+                templates = self.ct.get_available_templates(origin='library')
+
+                for tmpl in templates:
+                    expect(tmpl[2]).to(equal('library'))
+
+            with it('returns selected template'):
+                for key, tmpl in CONTRACT_TEMPLATES.items():
+                    template = self.ct.get_template(key)
+                    expect(template['description']).to(equal(tmpl['description']))
+
+            with it('raises Exception on inexistent template'):
+                expect(lambda *a: self.ct.get_template('FAKE')).to(raise_error(KeyError))
+
+    with describe('Generates B04'):
+        with before.all:
+            self.expected_result_20_ST = (
+                """
+                <Order IdPet="1234" IdReq="B04" Version="3.1.c">   
+                    <Cnc Id="CIR000000000">
+                        <Cnt Id="CNT000000000">
+                            <B04>
+                            <Contract c="1" CalendarType="01" CalendarName="322E305F5354" ActDate="{0}">
+                                   <Season Name="01" Start="FFFFFEFFFFFFFF0000800080" Week="01"/>
+                                   <Week Name="01" Week="01010101010101"/>
+                                   <Day id="01">
+                                     <Change Hour="01000000" TariffRate="0001"/>
+                                   </Day>
+                            </Contract>
+                            </B04>
+                        </Cnt>
+                    </Cnc>
+                </Order>
+                """
+            )
+            self.expected_result_30TDA = (
+                """
+                <Order IdPet="1234" IdReq="B04" Version="3.1.c">   
+                    <Cnc Id="CIR000000000">
+                        <Cnt Id="CNT000000000">
+                            <B04>
+                                <Contract c="1" CalendarType="01" CalendarName="332E30544441" ActDate="{0}">
+                                   <Season Name="01" Start="FFFF0101FF00000000800000" Week="01"/>
+                                   <Season Name="02" Start="FFFF0301FF00000000800000" Week="02"/>
+                                   <Season Name="03" Start="FFFF0401FF00000000800000" Week="03"/>
+                                   <Season Name="04" Start="FFFF0601FF00000000800000" Week="04"/>
+                                   <Season Name="05" Start="FFFF0701FF00000000800000" Week="01"/>
+                                   <Season Name="06" Start="FFFF0801FF00000000800000" Week="04"/>
+                                   <Season Name="07" Start="FFFF0A01FF00000000800000" Week="03"/>
+                                   <Season Name="08" Start="FFFF0B01FF00000000800000" Week="02"/>
+                                   <Season Name="09" Start="FFFF0C01FF00000000800000" Week="01"/>
+                                   <Week Name="01" Week="01010101010505"/>
+                                   <Week Name="02" Week="02020202020505"/>
+                                   <Week Name="03" Week="04040404040505"/>
+                                   <Week Name="04" Week="03030303030505"/>
+                                   <Day id="01">
+                                     <Change Hour="00000000" TariffRate="0006"/>
+                                     <Change Hour="08000000" TariffRate="0002"/>
+                                     <Change Hour="09000000" TariffRate="0001"/>
+                                     <Change Hour="0E000000" TariffRate="0002"/>
+                                     <Change Hour="12000000" TariffRate="0001"/>
+                                     <Change Hour="16000000" TariffRate="0002"/>
+                                   </Day>
+                                   <Day id="02">
+                                     <Change Hour="00000000" TariffRate="0006"/>
+                                     <Change Hour="08000000" TariffRate="0003"/>
+                                     <Change Hour="09000000" TariffRate="0002"/>
+                                     <Change Hour="0E000000" TariffRate="0003"/>
+                                     <Change Hour="12000000" TariffRate="0002"/>
+                                     <Change Hour="16000000" TariffRate="0003"/>
+                                   </Day>
+                                   <Day id="03">
+                                     <Change Hour="00000000" TariffRate="0006"/>
+                                     <Change Hour="08000000" TariffRate="0004"/>
+                                     <Change Hour="09000000" TariffRate="0003"/>
+                                     <Change Hour="0E000000" TariffRate="0004"/>
+                                     <Change Hour="12000000" TariffRate="0003"/>
+                                     <Change Hour="16000000" TariffRate="0004"/>
+                                   </Day>
+                                   <Day id="04">
+                                     <Change Hour="00000000" TariffRate="0006"/>
+                                     <Change Hour="08000000" TariffRate="0005"/>
+                                     <Change Hour="09000000" TariffRate="0004"/>
+                                     <Change Hour="0E000000" TariffRate="0005"/>
+                                     <Change Hour="12000000" TariffRate="0004"/>
+                                     <Change Hour="16000000" TariffRate="0005"/>
+                                   </Day>
+                                   <Day id="05">
+                                     <Change Hour="00000000" TariffRate="0006"/>
+                                   </Day>
+                                   <SpecialDays DT="FFFF0101000000000W" DTCard="Y" DayID="05"/>
+                                   <SpecialDays DT="FFFF0106000000000W" DTCard="Y" DayID="05"/>
+                                   <SpecialDays DT="FFFF0501000000000S" DTCard="Y" DayID="05"/>
+                                   <SpecialDays DT="FFFF0815000000000S" DTCard="Y" DayID="05"/>
+                                   <SpecialDays DT="FFFF1012000000000S" DTCard="Y" DayID="05"/>
+                                   <SpecialDays DT="FFFF1101000000000W" DTCard="Y" DayID="05"/>
+                                   <SpecialDays DT="FFFF1206000000000W" DTCard="Y" DayID="05"/>
+                                   <SpecialDays DT="FFFF1208000000000W" DTCard="Y" DayID="05"/>
+                                   <SpecialDays DT="FFFF1225000000000W" DTCard="Y" DayID="05"/>
+                                </Contract>
+                            </B04>
+                        </Cnt>
+                    </Cnc>
+                </Order>
+                """
+            )
+            self.expected_result_20TDA = (
+                """
+                <Order IdPet="1234" IdReq="B04" Version="3.1.c">   
+                    <Cnc Id="CIR000000000">
+                        <Cnt Id="CNT000000000">
+                            <B04>
+                                <Contract c="1" CalendarType="01" CalendarName="322E30544441" ActDate="{0}">
+                                   <Season Name="01" Start="FFFF0101FF00000000800000" Week="01"/>
+                                   <Week Name="01" Week="01010101010202"/>
+                                   <Day id="01">
+                                     <Change Hour="00000000" TariffRate="0003"/>
+                                     <Change Hour="08000000" TariffRate="0002"/>
+                                     <Change Hour="09000000" TariffRate="0001"/>
+                                     <Change Hour="0E000000" TariffRate="0002"/>
+                                     <Change Hour="12000000" TariffRate="0001"/>
+                                     <Change Hour="16000000" TariffRate="0002"/>
+                                   </Day>
+                                   <Day id="02">
+                                     <Change Hour="00000000" TariffRate="0003"/>
+                                   </Day>
+                                   <SpecialDays DT="FFFF0101000000000W" DTCard="Y" DayID="03"/>
+                                   <SpecialDays DT="FFFF0106000000000W" DTCard="Y" DayID="03"/>
+                                   <SpecialDays DT="FFFF0501000000000S" DTCard="Y" DayID="03"/>
+                                   <SpecialDays DT="FFFF0815000000000S" DTCard="Y" DayID="03"/>
+                                   <SpecialDays DT="FFFF1012000000000S" DTCard="Y" DayID="03"/>
+                                   <SpecialDays DT="FFFF1101000000000W" DTCard="Y" DayID="03"/>
+                                   <SpecialDays DT="FFFF1206000000000W" DTCard="Y" DayID="03"/>
+                                   <SpecialDays DT="FFFF1208000000000W" DTCard="Y" DayID="03"/>
+                                   <SpecialDays DT="FFFF1225000000000W" DTCard="Y" DayID="03"/>
+                                </Contract>
+                            </B04>
+                        </Cnt>
+                    </Cnc>
+                </Order>
+                """
+            )
+        with it('generates expected B04 xml with datetime as activation date'):
+
+            activation_dates = [
+                TZ.localize(datetime(2021, 4, 1, 0)),   # summer
+                TZ.localize(datetime(2020, 11, 1, 0)),  # winter
+                # not localized
+                datetime(2021, 8, 1, 0),  # summer
+                datetime(2020, 1, 1, 0),  # winter
+             ]
+
+            contracts = [
+                ('2.0_ST', self.expected_result_20_ST),
+                ('2.0TDA', self.expected_result_20TDA),
+                ('3.0TDA', self.expected_result_30TDA),
+            ]
+
+            generic_values = {
+                'id_pet': str(1234),
+                'id_req': 'B04',
+                'cnc': 'CIR000000000',
+                'cnt': 'CNT000000000'
+            }
+
+            for contract_name, contract_template in contracts:
+                for activation_date in activation_dates:
+                    payload = {
+                        'contract': 1,
+                        'name': contract_name,
+                        'activation_date': activation_date,
+                    }
+
+                    if activation_date.tzinfo is None:
+                        season = TZ.normalize(TZ.localize(activation_date)).dst() and 'S' or 'W'
+                    else:
+                        season = activation_date.dst() and 'S' or 'W'
+
+                    expected_activation_date = activation_date.strftime('%Y%m%d%H%M%S000{}'.format(season))
+                    expected_result = contract_template.format(expected_activation_date)
+
+                    order = Order('B04')
+                    order = order.create(generic_values, payload)
+                    assertXMLEqual(order, expected_result)


### PR DESCRIPTION
## Adds B04 contract modification order support.  

* It uses templates in `contract_templates.py` file
* It needs contract (1,2 or 3) to modify (`contract`) , activation date (`activation_date`), contract template name (`template`)

## Classes to create XML order
* Contract
* Season
* Week
* Day
* ChangeHour
* SpecialDays

## cli support