### PR TITLE
MOD 'line' to 'line supervisor'

### DIFF
--- a/primestg/order/base.py
+++ b/primestg/order/base.py
@@ -55,9 +55,9 @@ class Cnt(XmlModel):
 
 
 class LVSLine(XmlModel):
-    def __init__(self, line, drop_empty=False):
+    def __init__(self, line_supervisor, drop_empty=False):
         self.cnt = XmlField('LVSLine', attributes={
-                 'Id': line
+                 'Id': line_supervisor
         })
         self.payload = None
-        super(LVSLine, self).__init__('LVSLine', 'line', drop_empty=drop_empty)
+        super(LVSLine, self).__init__('LVSLine', 'line_supervisor', drop_empty=drop_empty)

--- a/primestg/order/orders.py
+++ b/primestg/order/orders.py
@@ -532,11 +532,11 @@ class B12Payload(XmlModel):
 
         data = template['data']
         sets = []
-        for set_line in data:
-            new_set = set_line.copy()
-            if set_line.get('data', False):
+        for set_line_supervisor in data:
+            new_set = set_line_supervisor.copy()
+            if set_line_supervisor.get('data', False):
                 # set (contains data)
-                new_set['data'] = set_line['data'].format(**params)
+                new_set['data'] = set_line_supervisor['data'].format(**params)
                 sets.append(Set(new_set))
             else:
                 # get (without data)

--- a/primestg/report/base.py
+++ b/primestg/report/base.py
@@ -695,17 +695,17 @@ class BaseElement(object):
         return self._warnings
     
 
-class Line(BaseElement):
+class LineSupervisor(BaseElement):
     """
-    Base class for a line.
+    Base class for a line supervisor.
     """
 
     @property
     def errors(self):
         """
-        The line errors.
+        The line supervisor errors.
 
-        :return: a dict with the line errors
+        :return: a dict with the line supervisor errors
         """
         self._errors = {}
         if self.objectified.get('ErrCat'):
@@ -734,7 +734,7 @@ class Line(BaseElement):
     @property
     def measures(self):
         """
-        Measure set objects of this line.
+        Measure set objects of this line supervisor.
 
         :return: a list of measure set objects
         """
@@ -747,7 +747,7 @@ class Line(BaseElement):
     @property
     def values(self):
         """
-        Values of measure sets of this line.
+        Values of measure sets of this line supervisor.
 
         :return: a list with the values of the measure sets
         """
@@ -757,20 +757,20 @@ class Line(BaseElement):
         return values
 
 
-class LineDetails(Line):
+class LineSupervisorDetails(LineSupervisor):
     """
-    Base class for a lines of report that need the name of the remote terminal unit in the values, like S52.
+    Base class for a line supervisors of report that need the name of the remote terminal unit in the values, like S52.
     """
 
-    def __init__(self, objectified_line, rt_unit_name):
+    def __init__(self, objectified_line_supervisor, rt_unit_name):
         """
-        Create a Line object using Line constructor and adding the remote terminal unit name.
+        Create a line supervisor object using line supervisor constructor and adding the remote terminal unit name.
 
-        :param objectified_line: an lxml.objectify.StringElement representing a line
+        :param objectified_line_supervisor: an lxml.objectify.StringElement representing a line supervisor
         :param rt_unit_name: a string with the name of the remote terminal unit
-        :return: a Line object
+        :return: a line supervisor object
         """
-        super(LineDetails, self).__init__(objectified_line)
+        super(LineSupervisorDetails, self).__init__(objectified_line_supervisor)
         self.rt_unit_name = rt_unit_name
 
     @property
@@ -794,7 +794,7 @@ class LineDetails(Line):
     @property
     def values(self):
         """
-        Values of measure sets of this line of report that need the name of the remote terminal unit and the line
+        Values of measure sets of this line supervisor of report that need the name of the remote terminal unit and the line supervisor
 
         :return: a list with the values of the measure sets
         """
@@ -815,18 +815,18 @@ class LineDetails(Line):
     @property
     def magnitude(self):
         """
-        The magnitude of the line measures.
+        The magnitude of the line supervisor measures.
 
-        :return: a int with the magnitude of the line measures
+        :return: a int with the magnitude of the line supervisor measures
         """
         return int(self.objectified.get('Magn'))
 
     @property
     def position(self):
         """
-        The position of the line measures.
+        The position of the line supervisor measures.
 
-        :return: a int with the position of the line measures
+        :return: a int with the position of the line supervisor measures
         """
         return int(self.objectified.get('Pos'))
 
@@ -837,37 +837,37 @@ class RemoteTerminalUnitDetails(BaseElement):
     """
 
     @property
-    def line_class(self):
+    def line_supervisor_class(self):
         """
-        The class to instance lines.
+        The class to instance line supervisors.
 
-        :return: a class to instance lines
+        :return: a class to instance line supervisors
         """
-        return Line
+        return LineSupervisor
 
     @property
     def values(self):
         """
-        Values of the lines of this remote terminal unit.
+        Values of the line supervisors of this remote terminal unit.
 
-        :return: a list with the values of the lines
+        :return: a list with the values of the line supervisors
         """
         values = []
-        for line in self.lines:
-            values.extend(line.values)
+        for line_supervisor in self.line_supervisors:
+            values.extend(line_supervisor.values)
         return values
 
     @property
-    def lines(self):
+    def line_supervisors(self):
         """
-        Line objects of this remote terminal unit. The name of remote terminal unit is passed to the line.
+        Line supervisor objects of this remote terminal unit. The name of remote terminal unit is passed to the line supervisor.
 
-        :return: a list of line objects
+        :return: a list of line supervisor objects
         """
-        lines = []
+        line_supervisors = []
         if getattr(self.objectified, 'LVSLine', None) is not None:
-            for line in self.objectified.LVSLine:
-                lines.append(self.line_class(line, self.name))
-            for line in lines:
-                self._warnings.append(line.warnings)
-        return lines
+            for line_supervisor in self.objectified.LVSLine:
+                line_supervisors.append(self.line_supervisor_class(line_supervisor, self.name))
+            for line_supervisor in line_supervisors:
+                self._warnings.append(line_supervisor.warnings)
+        return line_supervisors

--- a/primestg/report/reports.py
+++ b/primestg/report/reports.py
@@ -1,7 +1,7 @@
 from primestg.report.base import (
     MeasureActiveReactive, MeasureActiveReactiveFloat, Parameter,
     MeterWithMagnitude, ConcentratorWithMetersWithConcentratorName,
-    Concentrator, Measure, MeterWithConcentratorName, LineDetails, RemoteTerminalUnitDetails,
+    Concentrator, Measure, MeterWithConcentratorName, LineSupervisorDetails, RemoteTerminalUnitDetails,
     Operation
 )
 from primestg.message import MessageS
@@ -956,9 +956,9 @@ class ParameterConcentratorEvents(Parameter):
         return values
 
 
-class LineS52(LineDetails):
+class LineSupervisorS52(LineSupervisorDetails):
     """
-    Class for a line of report S52.
+    Class for a line supervisor of report S52.
     """
 
     @property
@@ -982,11 +982,12 @@ class LineS52(LineDetails):
     @property
     def values(self):
         """
-        Values of measure sets of this line of report that need the name of the remote terminal unit and the line
+        Values of measure sets of this line supervisor of report that need the name of the remote terminal unit
+        and the line supervisor
 
         :return: a list with the values of the measure sets
         """
-        values = super(LineS52, self).values
+        values = super(LineSupervisorS52, self).values
         for value in values:
             value['magn'] = self.magnitude
         return values
@@ -2006,13 +2007,13 @@ class RemoteTerminalUnitS52(RemoteTerminalUnitDetails):
     """
 
     @property
-    def line_class(self):
+    def line_supervisor_class(self):
         """
-        The class used to instance lines for report S52.
+        The class used to instance line supervisors for report S52.
 
-        :return: a class to instance lines of report S52
+        :return: a class to instance line supervisors of report S52
         """
-        return LineS52
+        return LineSupervisorS52
 
 
 class Report(object):

--- a/spec/Report_S52_spec.py
+++ b/spec/Report_S52_spec.py
@@ -11,7 +11,7 @@ with description('Report S52 example'):
         with open(self.data_filename) as data_file:
             self.report = Report(data_file)
 
-    with it('generates expected results for a value of the first line of '
+    with it('generates expected results for a value of the first line supervisor of '
             'first remote terminal unit'):
 
         expected_first_value = dict(
@@ -29,13 +29,13 @@ with description('Report S52 example'):
         )
 
         rt_unit = list(self.report.rt_units)[0]
-        line = list(rt_unit.lines)[0]
-        values = line.values
+        line_supervisor = list(rt_unit.line_supervisors)[0]
+        values = line_supervisor.values
 
-        first_value_first_line = {}
+        first_value_first_line_supervisor = {}
         for x in values:
             if x['timestamp'] == expected_first_value['timestamp']:
-                first_value_first_line = x
+                first_value_first_line_supervisor = x
 
-        expect(first_value_first_line)\
+        expect(first_value_first_line_supervisor)\
             .to(equal(expected_first_value))


### PR DESCRIPTION
Todo el módulo contenia las clases, variables y comentarios del Supervisor de línea como `line`. Ahora el supervisor de línea se llama `Line supervisor`.

**Class:**
`Line` --> `LineSupervisor`

**Variables:** 
`line` --> `line_supervisor`

**Comments:** 
`line` --> `line supervisor`