### PR TITLE
New S06 bad Te

### DIFF
--- a/primestg/message.py
+++ b/primestg/message.py
@@ -50,7 +50,10 @@ class BaseMessage(object):
             value = value.read()
         if is_gziped(value):
             value = zlib.decompress(value, zlib.MAX_WBITS | 32)
-        self._xml = value
+        try:
+            self._xml = value.decode('iso-8859-15')
+        except:
+            self._xml = value
         self._objectified = fromstring(self._xml)
 
 

--- a/spec/Report_S06_spec.py
+++ b/spec/Report_S06_spec.py
@@ -1,6 +1,7 @@
 from expects import expect, equal
 from primestg.report import Report
 from ast import literal_eval
+from io import open
 
 
 with description('Report S06 example'):
@@ -11,11 +12,12 @@ with description('Report S06 example'):
             'spec/data/S06_with_error.xml',
             'spec/data/S06_empty.xml',
             'spec/data/S06_empty_datetime.xml',
+            'spec/data/ZIV0004342071_0_S06_0_20231229102339', # no utf8
         ]
 
         self.report = []
         for data_filename in self.data_filenames:
-            with open(data_filename) as data_file:
+            with open(data_filename, encoding='iso-8859-15') as data_file:
                 self.report.append(Report(data_file))
 
     with it('generates the expected results for the whole report'):

--- a/spec/data/ZIV0004342071_0_S06_0_20231229102339
+++ b/spec/data/ZIV0004342071_0_S06_0_20231229102339
@@ -1,0 +1,7 @@
+<Report IdRpt="S06" IdPet="0" Version="3.2">
+<Cnc Id="ZIV0004342071">
+	<Cnt Id="ZIV0036394976">
+		<S06 Fh="20231229130822000W" NS="0036394976" Fab=" Z" Mod="NA" Af="14" Te="ÿÿÿÿÿÿÿÿÿÿ" Vf="VK016" VPrime="V2101" Pro="ÿÿÿÿÿÿÿ7" Idm="                        " Mac="40:40:22:2B:57:E0" Tp="" Ts="" Ip="" Is="" Usag="180" Uswell="180" Per="3600" Dctcp="95.00" Vr="230" Ut="180" UsubT="7.00" UsobT="7.00" UcorteT="50.00" AutMothBill="Y" ScrollDispMode="A" ScrollDispTime="3" />
+	</Cnt>
+</Cnc>
+</Report>

--- a/spec/data/ZIV0004342071_0_S06_0_20231229102339_result.txt
+++ b/spec/data/ZIV0004342071_0_S06_0_20231229102339_result.txt
@@ -1,0 +1,67 @@
+[
+    {
+        # IdPet
+        'request_id': '0',
+        # Version
+        'version': '3.2',
+        # Cnc
+        'concentrator': 'ZIV0004342071',
+        # Cnt
+        'meter': 'ZIV0036394976',
+        # Fh
+        'timestamp': '2023-12-29 13:08:22',
+        'season': 'W',
+        # NS
+        'serial_number': '0036394976',
+        # Fab
+        'manufacturer': ' Z',
+        # Mod
+        'model_type': 'NA',
+        # Af
+        'manufacturing_year': 14,
+        # Te
+        'equipment_type': u'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff',
+        # Vf
+        'firmware_version': 'VK016',
+        # VPrime
+        'prime_firmware_version': 'V2101',
+        # Pro
+        'protocol': u'\xff\xff\xff\xff\xff\xff\xff7',
+        # Idm
+        'id_multicast': '                        ',
+        # Mac
+        'mac': '40:40:22:2B:57:E0',
+        # Tp
+        'primary_voltage': 0,
+        # Ts
+        'secondary_voltage': 0,
+        # Ip
+        'primary_current': 0,
+        # Is
+        'secondary_current': 0,
+        # Usag
+        'time_threshold_voltage_sags': 180,
+        # Uswell
+        'time_threshold_voltage_swells': 180,
+        # Per
+        'load_profile_period': 3600,
+        # Dctcp
+        'demand_close_contracted_power': '95.00',
+        # Vr
+        'reference_voltage': 230,
+        # Ut
+        'long_power_failure_threshold': 180,
+        # UsubT
+        'voltage_sag_threshold': '7.00',
+        # UsobT
+        'voltage_swell_threshold': '7.00',
+        # UcorteT
+        'voltage_cut-off_threshold': '50.00',
+        # AutMothBill
+        'automatic_monthly_billing': True,
+        # ScrollDispMode
+        'scroll_display_mode': 'A',
+        # ScrollDispTime
+        'time_scroll_display': 3
+    }
+]


### PR DESCRIPTION
Some meters puts `\xff` characters in `Te` and `protocol` fields. Whe allow to read this files setting encoding to iso-8859-15 to allow it.

It is responsability of application to process this out of spec value.