### PR TITLE
FIX report_type on S52 classes

### DIFF
--- a/primestg/report/reports.py
+++ b/primestg/report/reports.py
@@ -2098,6 +2098,14 @@ class RemoteTerminalUnitS52(RemoteTerminalUnitDetails):
         """
         return LineSupervisorS52
 
+    @property
+    def report_type(self):
+        """
+        The type of report for report S64.
+        :return: a string with 'S52'
+        """
+        return 'S52'
+
 
 class Report(object):
     """


### PR DESCRIPTION
The classes for S52 reports didn't had report_type attributte