### PR TITLE
FIX - Add empty list as default value in get to avoid crashes

### DIFF
--- a/primestg/order/orders.py
+++ b/primestg/order/orders.py
@@ -389,7 +389,7 @@ class B07:
             generic_values.get('version', '3.1.c'),
         )
         b07 = B07Payload(payload)
-        tasks = payload.get("tasks")
+        tasks = payload.get("tasks", [])
         for task in tasks:
             tppros = task.pop("TpPro")
             task_xml = B07Task(task)


### PR DESCRIPTION
- Avoid crashes when creating B07 in case there are no tasks to send