### PR TITLE
Fix requirements py2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+isodate;python_version>"2.7.18"
+isodate<0.7.0;python_version<="2.7.18"
 lxml
 libComXML
 pytz


### PR DESCRIPTION
https://pypi.org/project/isodate/#history

New isodate release 0.0.7 is not py2 compatible