### PR TITLE
Añadir parámetros "period", "immediate" y "repeat" en la función "generate_cycles" + Test

### DIFF
--- a/primestg/utils.py
+++ b/primestg/utils.py
@@ -183,22 +183,27 @@ class DLMSTemplates(PrimeTemplates):
         else:
             return cycles_xml
 
-    def generate_cycles(self, template_name, meters_name, params=None):
+    def generate_cycles(self, template_name, meters_name, period='1', immediate=True, repeat='1', params=None):
         elements = self.get_template(template_name)['data']
         if params is None:
             params = {}
         else:
             params = prepare_params(params)
 
-        xml = '<cycle name="Ciclo_{}_raw" period="1" immediate="true" repeat="1" priority="1">\n'.format(
-            template_name)
+        xml = '<cycle name="Cicle_{}_raw" period="{}" immediate={} repeat="{}" priority="1">\n'.format(
+            template_name, period, immediate, repeat)
 
         for meter_name in meters_name:
             xml += '<device sn="{}"/>\n'.format(meter_name)
 
-        for element in elements:
-            xml += '<set obis="{}" class="{}" element="{}">{}</set>\n'.format(
+        if 'data' in elements[0]:
+            for element in elements:
+                xml += '<set obis="{}" class="{}" element="{}"/>{}</set>\n'.format(
                 element['obis'], element['class'], element['element'], element['data'].format(**params))
+        else:
+            for element in elements:
+                xml += '<get obis="{}" class="{}" element="{}"/>'.format(
+                element['obis'], element['class'], element['element'])
 
         xml += '</cycle>'
 

--- a/primestg/utils.py
+++ b/primestg/utils.py
@@ -183,14 +183,14 @@ class DLMSTemplates(PrimeTemplates):
         else:
             return cycles_xml
 
-    def generate_cycles(self, template_name, meters_name, period='1', immediate=True, repeat='1', params=None):
+    def generate_cycles(self, template_name, meters_name, period='1', immediate="true", repeat='1', params=None):
         elements = self.get_template(template_name)['data']
         if params is None:
             params = {}
         else:
             params = prepare_params(params)
 
-        xml = '<cycle name="Cicle_{}_raw" period="{}" immediate={} repeat="{}" priority="1">\n'.format(
+        xml = '<cycle name="Cicle_{}_raw" period="{}" immediate="{}" repeat="{}" priority="1">\n'.format(
             template_name, period, immediate, repeat)
 
         for meter_name in meters_name:

--- a/spec/cycle_spec.py
+++ b/spec/cycle_spec.py
@@ -134,11 +134,11 @@ with description("Function generate_cycles with GET_INSTANT"):
             template_name='GET_INSTANT',
             meters_name=meters,
             period='15',
-            immediate=False,
+            immediate='false',
             repeat='96'
         )
 
-        expect(xml).to(contain('<cycle name="Cicle_GET_INSTANT_raw" period="15" immediate=False repeat="96" priority="1">'))
+        expect(xml).to(contain('<cycle name="Cicle_GET_INSTANT_raw" period="15" immediate="false" repeat="96" priority="1">'))
         expect(xml).to(contain('<device sn="123456789"/>'))
         expect(xml).to(contain('<get obis="0.0.21.0.5.255" class="7" element="2"/>'))
         expect(xml).to(contain('</cycle>'))

--- a/spec/cycle_spec.py
+++ b/spec/cycle_spec.py
@@ -1,5 +1,6 @@
 from primestg.cycle.cycles import CycleFile
-from expects import expect, equal
+from primestg.utils import DLMSTemplates
+from expects import expect, equal, contain
 import io
 from datetime import datetime
 
@@ -122,6 +123,26 @@ with description('Parse CNC cycles'):
                 expect(len(expected['data'])).to(equal(len(cycle_data['data'])))
                 for i in range(0, len(cycle_data['data'])):
                     expect(expected['data'][i]).to(equal(cycle_data['data'][i]))
+
+with description("Function generate_cycles with GET_INSTANT"):
+
+    with it("Generar correctament un cicle DLMS"):
+
+        generator = DLMSTemplates()
+        meters = ['123456789']
+        xml = generator.generate_cycles(
+            template_name='GET_INSTANT',
+            meters_name=meters,
+            period='15',
+            immediate=False,
+            repeat='96'
+        )
+
+        expect(xml).to(contain('<cycle name="Cicle_GET_INSTANT_raw" period="15" immediate=False repeat="96" priority="1">'))
+        expect(xml).to(contain('<device sn="123456789"/>'))
+        expect(xml).to(contain('<get obis="0.0.21.0.5.255" class="7" element="2"/>'))
+        expect(xml).to(contain('</cycle>'))
+
 
 
 


### PR DESCRIPTION
## Objetivos

- Modificar función generate_cycles para poder pasar por parámetro más datos ("period", "immediate" y "repeat"). Modificación de la función para que funcione según si se le pasa "data" o no y tests de comprobación con template 'GET_INSTANT'.

## Afectaciones / Migración de datos

- [x] Código. Reiniciar servicios

## Relacionado

- Origen de la tarea: TASK-74164
