### PR TITLE
FIX spureous slash in cycles generation

### DIFF
--- a/primestg/utils.py
+++ b/primestg/utils.py
@@ -205,7 +205,7 @@ class DLMSTemplates(PrimeTemplates):
 
         if 'data' in elements[0]:
             for element in elements:
-                xml += '<set obis="{}" class="{}" element="{}"/>{}</set>\n'.format(
+                xml += '<set obis="{}" class="{}" element="{}">{}</set>\n'.format(
                 element['obis'], element['class'], element['element'], element['data'].format(**params))
         else:
             for element in elements:


### PR DESCRIPTION
Spurious closing slash (\) in cycle generation.

fixes #131 